### PR TITLE
Fix avg_upstream_response_time

### DIFF
--- a/status_counter/status_counter_init.rb
+++ b/status_counter/status_counter_init.rb
@@ -64,6 +64,7 @@ class StatusCounter
 
     if Time.now.to_i - stats[:period_updated] > 300
       stats[:avg_request_time] = nil
+      stats[:avg_upstream_response_time] = nil
     end
 
     out = {


### PR DESCRIPTION
Reset avg_upstream_response_time which were not updated for a long period.